### PR TITLE
hardwire build version in primazactl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ cython_debug/
 
 *.swp
 *.swo
+
+# primazactl version file created as part of the build process
+scripts/src/primazactl/version.py

--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@
    - [Pre-reqs](#pre-reqs)
    - [Help](#help)  
    - [Command summary](#command-summary)
-   - [Main install command](#main-install-command)  
-     - [Help](#main-install-help)
-     - [Options](#main-install-options)
-  - [Worker join command](#worker-join-command)
-     - [Help](#worker-join-help)
-     - [Options](#worker-join-options)
-  - [Worker create application namespace command](#worker-create-application-namespace-command)
-    - [Help](#worker-create-application-namespace-help)
-    - [Options](#worker-create-application-namespace-options)
-  - [Worker create service namespace command](#worker-create-service-namespace-command)
-    - [Help](#worker-create-service-namespace-help)
-    - [Options](#worker-create-service-namespace-options)
+   - [create tenant](#create-tenant-command) 
+     - [Help](#create-tenant-help)
+     - [Options](#create-tenant-options)
+   - [delete tenant](#delete-tenant-command)
+     - [Help](#delete-tenant-help)
+     - [Options](#delete-tenant-options)     
+    - [join cluster](#join-cluster-command)
+     - [Help](#join-cluster-help)
+     - [Options](#join-cluster-options)
+    - [create application-namespace](#create-application-namespace-command)
+      - [Help](#create-application-namespace-help) 
+      - [Options](#create-application-namespace-options)
+    - [create service-namespace](#create-service-namespace-command)
+        - [Help](#create-service-namespace-help)
+        - [Options](#create-service-namespace-options)
  - [Testing](#testing) 
 
 
@@ -25,10 +28,13 @@
 `primazactl` is a simple Command Line Application for Primaza Administrators.
 
 The current implementation provides:
-- [main install](#main-install-command) and uninstall.
-- [worker join](#worker-install-command).
-- [worker create service-namespace](#worker-create-service-namespace-command).
-- [worker create application-namespace](#worker-create-application-namespace-command).
+- [Create tenant](#create-tenant-command).
+- [Delete tenant](#delete-tenant-command).  
+- [Join cluster](#join-cluster-command).
+- [Create service-namespace](#create-service-namespace-command).
+- [Create application-namespace](#create-application-namespace-command).
+
+For information about primaza see: [Primaza readme](https://github.com/primaza/primaza#readme)
 
 
 # Building the tool
@@ -37,7 +43,7 @@ The current implementation provides:
 1. Run: `make primazactl`
 1. Tool will be available in `out/venv3/bin/primazactl`
 1. For example, from the repository root directory:
-  - `out/venv3/bin/primazactl install main -f primaza-config.yaml`
+  - `out/venv3/bin/primazactl create tenant primaza-system`
 
 # Running the tool
 
@@ -46,61 +52,70 @@ The current implementation provides:
 - kubectl installed and a kube-apiserver available.
     - see: [kubernetes documentation](https://kubernetes.io/docs/home/)
 - docker    
-- a cluster available for primaza to be installed.
-  - get a kind cluster by running `make kind-cluster`.
-    - default cluster name is primazactl-test.
-      - set environment variable `KIND_CONTEXT` to overwrite.
-    - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind.yaml`. 
-      - set environment variable `KIND_CONFIG_FILE` to overwrite.
+- a cluster for the tenant and a cluster to join to the tenant.
+  - get two kind clusters by running `make kind-cluster`.
+    - tenant cluster:
+        - default cluster name is primazactl-tenant-test.
+        - set environment variable `KIND_CLUSTER_TENANT_NAME` to overwrite.
+        - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind-main.yaml`. 
+        - set environment variable `TENANAT_KIND_CONFIG_FILE` to overwrite.
+    - join cluster:
+        - default cluster name is primazactl-join-test.
+        - set environment variable `KIND_CLUSTER_JOIN_NAME` to overwrite.
+        - the configuration file used when creating the cluster is `scripts/src/primazatest/config/kind-worker.yaml`.
+        - set environment variable `JOIN_KIND_CONFIG_FILE` to overwrite.
     - For information on kind see : (kind quick start)[https://kind.sigs.k8s.io/docs/user/quick-start/].
-- a certificate manager available in the cluster on which primaza main will be installed.
+- a certificate manager available in the cluster on which primaza tenant will be installed.
   - `make kind cluster` installs a certificate manager.
 
 ## Help
 
 Primazactl help is organized in a hierarchy with contextual help available for different commands:
 - `primazactl --help`
-- `primazactl main --help`
-- `primazactl main install --help`
-- `primazactl main uninstall --help`
-- `primazactl worker --help`
-- `primazactl worker join --help`
-- `primazactl worker create --help`
-- `primazactl worker create application-namespace --help`
-- `primazactl worker create service-namespace --help`
+- `primazactl create --help`
+- `primazactl create tenant --help`
+- `primazactl delete --help`
+- `primazactl delete tenant --help`
+- `primazactl join --help`
+- `primazactl join cluster --help`
+- `primazactl create application-namespace --help`
+- `primazactl create service-namespace --help`
 
 ## Command Summary
 
-- Main Install
+- Create tenant
   - creates a specified namespace, default is `primaza-system`.
     - control-plane `primaza-controller-manager`
     - default image installed: `ghcr.io/primaza/primaza:latest`
-  - adds kubernetes resources required by primaza-main  
-- Worker Join
-    - requires main to be installed first.
-    - add kubernetes resources required by primaza-worker
-    - creates an [indentity](docs/identities.md#identities) in the worker namespace which is shared with primaza main.   
-    - creates a cluster-environment resource in main to enable main-worker communication.
-- Worker create application-namespace.
-    - requires worker join to be complete first.
+  - adds kubernetes resources required by primaza tenant.  
+- Join cluster
+    - requires tenant to be created first.
+    - add kubernetes resources required to join a cluster.
+    - creates an [indentity](docs/identities.md#identities) which is shared with the primaza tenant.   
+    - creates a cluster-environment resource in primaza tenant to enable communication with the joined cluster.
+- Create application-namespace.
+    - requires join cluster to be complete first.
     - creates a specified namespace, default is `primaza-application`.
-    - creates an [indentity](docs/identities.md#identities) in the main namespace which is shared with the application namespace.
-        - enables primaza main to access the namespace
+    - creates an [indentity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the application namespace.
+        - enables primaza tenant to access the namespace
     - creates a service account for the application-namespace to access kubernetes resources.
-    - provides primaza worker service account with access to the namespace
-- Worker create primaza-service.
-    - requires worker join to be complete first.
+    - provides join cluster primaza service account with access to the namespace
+- Create service-namespace.
+    - requires join cluster to be complete first.
     - creates a specified namespace, default is `primaza-service`.
-    - creates an [indentity](docs/identities.md#identities) in the main namespace which is shared with the service namespace.
-        - enables primaza main to access the namespace
+    - creates an [indentity](docs/identities.md#identities) in the primaza tenant namespace which is shared with the service namespace.
+        - enables primaza tenant to access the namespace
     - creates two service accounts for the service-namespace to access kubernetes resources based on two different roles.
-    - provides primaza worker service account with access to the namespace
+    - provides join cluster service account with access to the namespace
     
-## Main install command
+## Create tenant command
 
-### Main install help
+### Create tenant help
 ```
-usage: primazactl main install [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] [-n NAMESPACE]
+usage: primazactl create tenant [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] tenant
+
+positional arguments:
+  tenant                tenant to create. Default: primaza-system
 
 options:
   -h, --help            show this help message and exit
@@ -108,16 +123,13 @@ options:
   -f CONFIG, --config CONFIG
                         primaza config file. Takes precedence over --version
   -v VERSION, --version VERSION
-                        Version of primaza to use. Ignored if --config is set.
+                        Version of primaza to use, default: latest. Ignored if --config is set.
   -c CONTEXT, --context CONTEXT
-                        name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which to create the tenant, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
-                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise <USER-HOME>.kube/config
-  -n NAMESPACE, --namespace NAMESPACE
-                        namespace to use for install. Default: primaza-system
-
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
 ```
-### Main install options
+### Create tenant options
  - `--config CONFIG`:
     - CONFIG: the manifest file for installing primaza main
     - To generate a suitable manifest file:
@@ -127,11 +139,11 @@ options:
       - The manifest file sets the image to `ghcr.io/primaza/primaza:latest`
           - Set the environment variable `IMG` before running make to overwrite the image used.
  - `--context CONTEXT`:
-    - CONTEXT: the cluster, as it appears in kubeconfig, on which to install primaza main
+    - CONTEXT: the cluster, as it appears in kubeconfig, on which to install primaza tenant.
     - To create a kind cluster to use for testing:
         - Run `make kind-cluster` 
-            - The cluster created for main install is `primazactl-main-test`
-            - Set the environment variable `KIND_CLUSTER_MAIN_NAME` before running make to overwrite the name of the cluster created.
+            - The cluster created for main install is `primazactl-tenant-test`
+            - Set the environment variable `KIND_CLUSTER_TENANT_NAME` before running make to overwrite the name of the cluster created.
     - If using kind, prepend `kind-` to the cluster name.
  - `--kubeconfig KUBECONFIG` 
     - The kubeconfig file is not modified by primazactl.
@@ -140,21 +152,13 @@ options:
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.    
         - Ignored if a config file is set.
- - `--namespace NAMESPACE`  
-   - Namespace to use for primaza main.
-   - Default is `primaza-system`.
+        - defaults to the version used to build primazactl.
 
-## Worker join command
+## Delete tenant command
 
-Notes:
-- requires primaza main installed.
-- the namespace created is named `kube-system`.
-  - Not currently supported to use a different name.
-
-
-### Worker join help
+### Delete tenant help
 ```
-usage: primazactl worker join [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] -d CLUSTER_ENVIRONMENT -e ENVIRONMENT [-l MAIN_KUBECONFIG] [-m TENANT_CONTEXT]
+usage: primazactl delete tenant [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG]
 
 options:
   -h, --help            show this help message and exit
@@ -162,9 +166,39 @@ options:
   -f CONFIG, --config CONFIG
                         primaza config file. Takes precedence over --version
   -v VERSION, --version VERSION
-                        Version of primaza to use. Ignored if --config is set.
+                        Version of primaza to use, default: latest. Ignored if --config is set.
   -c CONTEXT, --context CONTEXT
-                        name of cluster, as it appears in kubeconfig, on which to install primaza or worker, default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which primaza tenant was created, default: current kubeconfig context
+  -k KUBECONFIG, --kubeconfig KUBECONFIG
+                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+```
+
+### Delete tenant options
+
+see: [Create tenant options](#create-tenant-options).
+
+
+## Join cluster command
+
+Notes:
+- requires a primaza tenant.
+- the namespace created is named `kube-system`.
+  - Not currently supported to use a different name.
+
+
+### Join cluster help
+```
+usage: primazactl join cluster [-h] [-x] [-f CONFIG] [-v VERSION] [-c CONTEXT] [-k KUBECONFIG] -d CLUSTER_ENVIRONMENT -e ENVIRONMENT [-l MAIN_KUBECONFIG] [-m TENANT_CONTEXT] [-t TENANT]
+
+options:
+  -h, --help            show this help message and exit
+  -x, --verbose         Set for verbose output
+  -f CONFIG, --config CONFIG
+                        primaza config file. Takes precedence over --version
+  -v VERSION, --version VERSION
+                        Version of primaza to use, default: latest. Ignored if --config is set.
+  -c CONTEXT, --context CONTEXT
+                        name of cluster, as it appears in kubeconfig, to join, default: current kubeconfig context
   -k KUBECONFIG, --kubeconfig KUBECONFIG
                         path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
   -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
@@ -172,24 +206,25 @@ options:
   -e ENVIRONMENT, --environment ENVIRONMENT
                         the Environment that will be associated to the ClusterEnvironment
   -l MAIN_KUBECONFIG, --tenant-kubeconfig MAIN_KUBECONFIG
-                        path to kubeconfig file, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
+                        path to kubeconfig file for the tenant, default: KUBECONFIG environment variable if set, otherwise /Users/martinmulholland/.kube/config
   -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
-                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
-  -s MAIN_NAMESPACE, --main-namespace MAIN_NAMESPACE
-                        namespace to use for join. Default: primaza-system
+                        name of cluster, as it appears in kubeconfig, on which primaza tenant was created. Default: current kubeconfig context
+  -t TENANT, --tenant TENANT
+                        tenant to use for join. Default: primaza-system
 ```
-### Worker join options
+
+### Join cluster options
 - `--config CONFIG`:
-    - CONFIG contains the manifest file for the primaza worker.
+    - CONFIG contains the manifest file for the join cluster.
     - To generate a suitable manifest file:
         - Run `make config` from the repository
         - The manifest will be created: `out/config/worker_config_latest.yaml` 
-- `--context CONTEXT` 
-    - CONTEXT: the cluster, as it appears in kubeconfig, on which to add primaza-worker
+- `--context CONTEXT`: 
+    - CONTEXT: the cluster, as it appears in kubeconfig, of the join cluster.
     - To create a kind cluster to use for testing:
         - Run `make kind-cluster`
-            - The cluster created for the worker is `primazactl-worker-test`
-            - Set the environment variable `KIND_CLUSTER_WORKER_NAME` before running make to overwrite the name of the cluster created.
+            - The cluster created for the worker is `primazactl-join-test`
+            - Set the environment variable `KIND_CLUSTER_JOIN_NAME` before running make to overwrite the name of the cluster created.
     - If using kind, prepend `kind-` to the cluster name.
     - Can use the same cluster as used for main install.
 - `--kubeconfig KUBECONFIG`
@@ -199,27 +234,31 @@ options:
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
         - Ignored if a config file is set.
+        - defaults to the version used to build primazactl.
 - `--cluster-environment CLUSTER_ENVIRONMENT`
     - name to be used for the cluster environment resource created in the primaza-main namespace.
 - `--environment ENVIRONMENT`
     - the name that will be associated to the ClusterEnvironment,
 - `--tenant-kubeconfig MAIN_KUBECONFIG`
-    - only set if the cluster on which primaza main installed is in a different kubeconfig file from the one set using the `--kubeconfig` option.
+    - only set if the cluster on which primaza tenant installed is in a different kubeconfig file from the one set using the `--kubeconfig` option.
 - `--tenant-context TENANT_CONTEXT`
-    - only set if cluster on which primaza main is installed is different from the one set using the `--context` option.
-- `--main-namespace MAIN_NAMESPACE`
-    - Namespace of primaza-main.
+    - only set if cluster on which primaza tenant is installed is different from the one set using the `--context` option.
+- `--tenant tenant`
+    - Tenant used for the join.
     - Default is `primaza-system`.
     
 
-## Worker create application namespace command
+## Create application namespace command
 
 Notes:
-- requires primaza worker join to be completed.
+- requires join cluster to be completed.
 
-### Worker create application-namespace help
+### Create application-namespace help
 ```
-usage: primazactl worker create application-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CONTEXT] [-m TENANT_CONTEXT] [-f CONFIG]
+usage: primazactl create service-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CONTEXT] [-m TENANT_CONTEXT] [-f CONFIG] [-t TENANT] [-v VERSION] namespace
+
+positional arguments:
+  namespace             namespace to create
 
 options:
   -h, --help            show this help message and exit
@@ -227,20 +266,22 @@ options:
   -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
   -c CONTEXT, --context CONTEXT
-                        name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which to create the service or application namespace, default: current kubeconfig context
   -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
-                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which Primaza tenant was created. Default: current kubeconfig context
   -f CONFIG, --config CONFIG
                         Config file containing agent roles
-  -n NAMESPACE, --namespace NAMESPACE
-                        namespace to create. Default: primaza-application
-  -s MAIN_NAMESPACE, --main-namespace MAIN_NAMESPACE
-                        namespace of primaza main. Default: primaza-system
+  -t TENANT, --tenant TENANT
+                        tenant to use. Default: primaza-system
   -v VERSION, --version VERSION
-                        Version of primaza to use. Ignored if --config is set.                        
+                        Version of primaza to use, default: latest. Ignored if --config is set.
 ```
 
-### Worker create application-namespace options: 
+### Create application-namespace options: 
+#### positional arguments:
+- `namespace`
+    - Namespace to use for application agent.
+#### options:
 - `--context CONTEXT`
     - CONTEXT: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
 - `--cluster-environment CLUSTER_ENVIRONMENT`
@@ -252,25 +293,23 @@ options:
     - To generate a suitable config file:
         - Run `make config` from the repository
         - The config will be created: `out/config/application_agent_config_latest.yaml`
-- `--namespace NAMESPACE`
-    - Namespace to use for application agent.
-    - Default is `primaza-application`. 
-- `--main-namespace MAIN_NAMESPACE`
-     - Namespace of primaza-main.
+- `--tenant TENANT`
+     - tenant to use.
      - Default is `primaza-system`.
 - `--version VERSION`
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
         - Ignored if a config file is set.
+        - Default is the version used to build primazactl.
     
 
-## Worker create service namespace command
+## Create service namespace command
 
 Notes:
-- requires primaza worker join to be completed.
+- requires join cluster to be completed.
 
     
-### Worker create service-namespace help:
+### Create service-namespace help:
 ```
 usage: primazactl worker create service-namespace [-h] [-x] -d CLUSTER_ENVIRONMENT [-c CONTEXT] [-m TENANT_CONTEXT] [-f CONFIG]
 
@@ -280,20 +319,22 @@ options:
   -d CLUSTER_ENVIRONMENT, --cluster-environment CLUSTER_ENVIRONMENT
                         name to use for the ClusterEnvironment that will be created in Primaza
   -c CONTEXT, --context CONTEXT
-                        name of worker cluster, as it appears in kubeconfig, on which to create the namespace, default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which to create the service or application namespace, default: current kubeconfig context
   -m TENANT_CONTEXT, --tenant-context TENANT_CONTEXT
-                        name of cluster, as it appears in kubeconfig, on which Primaza is installed. Default: current kubeconfig context
+                        name of cluster, as it appears in kubeconfig, on which Primaza tenant was created. Default: current kubeconfig context
   -f CONFIG, --config CONFIG
                         Config file containing agent roles
-  -n NAMESPACE, --namespace NAMESPACE
-                        namespace to create. Default: primaza-service
-  -s MAIN_NAMESPACE, --main-namespace MAIN_NAMESPACE
-                        namespace of primaza main. Default: primaza-system
+  -t TENANT, --tenant TENANT
+                        tenant to use. Default: primaza-system
   -v VERSION, --version VERSION
-                        Version of primaza to use. Ignored if --config is set.                                                
+                        Version of primaza to use, default: latest. Ignored if --config is set.                                                
 ```
 
-### Worker create service-namespace options: 
+### Create service-namespace options: 
+#### positional arguments:
+- `namespace`
+    - Namespace to use for service agent.
+#### options:
 - `--context CONTEXT`
     - CONTEXT: the cluster, as it appears in kubeconfig, on which primaza-worker is installed
 - `--cluster-environment CLUSTER_ENVIRONMENT`
@@ -305,16 +346,14 @@ options:
     - To generate a suitable config file:
         - Run `make config` from the repository
         - The config will be created: `out/config/service_agent_config_latest.yaml`
-- `--namespace NAMESPACE`
-    - Namespace to use for service agent.
-    - Default is `primaza-service`.
 - `--main-namespace MAIN_NAMESPACE`
     - Namespace of primaza-main.
     - Default is `primaza-system`.
 - `--version VERSION`
     - Specify the version of manifests to use.
         - see: [releases](https://github.com/primaza/primazactl/releases) for available versions.
-        - Ignored if a config file is set.    
+        - Ignored if a config file is set.
+        - Defaults to the version used to build primazactl.
     
 # Testing
 

--- a/scripts/src/primazactl/cmd/create/common.py
+++ b/scripts/src/primazactl/cmd/create/common.py
@@ -1,9 +1,9 @@
 import os
 import argparse
 from pathlib import Path
-from primazactl.errors import AtLeastOneError
 from primazactl.types import existing_file, semvertag_or_latest
 from primazactl.utils.kubeconfig import from_env
+from primazactl.version import __version__
 
 
 def add_shared_args(parser: argparse.ArgumentParser):
@@ -19,8 +19,10 @@ def add_shared_args(parser: argparse.ArgumentParser):
         "-v", "--version",
         dest="version",
         required=False,
-        help="Version of primaza to use. Ignored if --config is set.",
-        type=semvertag_or_latest)
+        help=f"Version of primaza to use, default: {__version__}. "
+             "Ignored if --config is set.",
+        type=semvertag_or_latest,
+        default=__version__)
 
     # main
     parser.add_argument(
@@ -28,9 +30,8 @@ def add_shared_args(parser: argparse.ArgumentParser):
         dest="context",
         type=str,
         required=False,
-        help="name of cluster, as it appears in kubeconfig, \
-                  on which to install primaza or worker, default: \
-                  current kubeconfig context",
+        help="name of cluster, as it appears in kubeconfig, on which to "
+             "create the tenant, default: current kubeconfig context",
         default=None)
 
     parser.add_argument(
@@ -42,8 +43,3 @@ def add_shared_args(parser: argparse.ArgumentParser):
                    {(os.path.join(Path.home(),'.kube','config'))}",
         type=existing_file,
         default=from_env())
-
-
-def validate(args):
-    if not args.config and not args.version:
-        raise AtLeastOneError("--config", "--version")

--- a/scripts/src/primazactl/cmd/create/namespace/common.py
+++ b/scripts/src/primazactl/cmd/create/namespace/common.py
@@ -8,6 +8,7 @@ from primazactl.primazaworker.workernamespace import WorkerNamespace
 from primazactl.primazaworker.workercluster import WorkerCluster
 from primazactl.primazamain.maincluster import MainCluster
 from primazactl.primazamain.constants import DEFAULT_TENANT
+from primazactl.version import __version__
 from .constants import SERVICE, APPLICATION
 
 
@@ -30,9 +31,9 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
         dest="context",
         type=str,
         required=False,
-        help="name of worker cluster, as it appears in kubeconfig, \
-                  on which to create the namespace, default: \
-                  current kubeconfig context",
+        help="name of cluster, as it appears in kubeconfig, "
+             "on which to create the service or application namespace, "
+             "default: current kubeconfig context",
         default=None)
 
     parser.add_argument(
@@ -40,7 +41,7 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
         dest="tenant_context",
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
-                on which Primaza is installed. Default: \
+                on which Primaza tenant was created. Default: \
                 current kubeconfig context",
         type=str,
         default=None)
@@ -64,8 +65,10 @@ def add_args_namespace(parser: argparse.ArgumentParser, type):
         "-v", "--version",
         dest="version",
         required=False,
-        help="Version of primaza to use. Ignored if --config is set.",
-        type=semvertag_or_latest)
+        help=f"Version of primaza to use, default: {__version__}. "
+             "Ignored if --config is set.",
+        type=semvertag_or_latest,
+        default=__version__)
 
 
 def __create_namespace(args, type):

--- a/scripts/src/primazactl/cmd/create/tenant/parser.py
+++ b/scripts/src/primazactl/cmd/create/tenant/parser.py
@@ -1,7 +1,7 @@
 import argparse
 import traceback
 import sys
-from primazactl.cmd.create.common import add_shared_args, validate
+from primazactl.cmd.create.common import add_shared_args
 from primazactl.primazamain.constants import DEFAULT_TENANT
 from primazactl.primazamain.maincluster import MainCluster
 from primazactl.types import kubernetes_name
@@ -24,12 +24,13 @@ def add_args_tenant(parser: argparse.ArgumentParser):
     parser.add_argument(
         "tenant",
         type=kubernetes_name,
+        nargs='?',
         help=f"tenant to create. Default: \
-            {DEFAULT_TENANT}")
+            {DEFAULT_TENANT}",
+        default=DEFAULT_TENANT)
 
 
 def create_tenant(args):
-    validate(args)
     try:
         MainCluster(
             args.context,

--- a/scripts/src/primazactl/cmd/delete/tenant/common.py
+++ b/scripts/src/primazactl/cmd/delete/tenant/common.py
@@ -1,9 +1,9 @@
 import os
 import argparse
 from pathlib import Path
-from primazactl.errors import AtLeastOneError
 from primazactl.types import existing_file, semvertag_or_latest
 from primazactl.utils.kubeconfig import from_env
+from primazactl.version import __version__
 
 
 def add_shared_args(parser: argparse.ArgumentParser):
@@ -19,8 +19,10 @@ def add_shared_args(parser: argparse.ArgumentParser):
         "-v", "--version",
         dest="version",
         required=False,
-        help="Version of primaza to use. Ignored if --config is set.",
-        type=semvertag_or_latest)
+        help=f"Version of primaza to use, default: {__version__}. "
+             "Ignored if --config is set.",
+        type=semvertag_or_latest,
+        default=__version__)
 
     # main
     parser.add_argument(
@@ -29,7 +31,7 @@ def add_shared_args(parser: argparse.ArgumentParser):
         type=str,
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
-                  on which to install primaza or worker, default: \
+                  on which the primaza tenant was created, default: \
                   current kubeconfig context",
         default=None)
 
@@ -42,8 +44,3 @@ def add_shared_args(parser: argparse.ArgumentParser):
                    {(os.path.join(Path.home(),'.kube','config'))}",
         type=existing_file,
         default=from_env())
-
-
-def validate(args):
-    if not args.config and not args.version:
-        raise AtLeastOneError("--config", "--version")

--- a/scripts/src/primazactl/cmd/delete/tenant/parser.py
+++ b/scripts/src/primazactl/cmd/delete/tenant/parser.py
@@ -1,7 +1,7 @@
 import argparse
 import traceback
 import sys
-from .common import add_shared_args, validate
+from .common import add_shared_args
 from primazactl.primazamain.maincluster import MainCluster
 
 
@@ -15,7 +15,6 @@ def add_delete_tenant(parser: argparse.ArgumentParser, parents=[]):
 
 
 def delete_tenant(args):
-    validate(args)
     try:
         MainCluster(
             args.context,

--- a/scripts/src/primazactl/cmd/join/parser.py
+++ b/scripts/src/primazactl/cmd/join/parser.py
@@ -3,13 +3,13 @@ import argparse
 import traceback
 import sys
 from pathlib import Path
-from primazactl.errors import AtLeastOneError
 from primazactl.types import \
     existing_file, kubernetes_name, semvertag_or_latest
 from primazactl.primazamain.maincluster import MainCluster
 from primazactl.primazaworker.workercluster import WorkerCluster
 from primazactl.utils.kubeconfig import from_env
 from primazactl.primazamain.constants import DEFAULT_TENANT
+from primazactl.version import __version__
 
 
 def add_group(parser: argparse.ArgumentParser, parents=[]):
@@ -42,8 +42,10 @@ def add_args_join(parser: argparse.ArgumentParser):
         "-v", "--version",
         dest="version",
         required=False,
-        help="Version of primaza to use. Ignored if --config is set.",
-        type=semvertag_or_latest)
+        help=f"Version of primaza to use, default: {__version__}. "
+             "Ignored if --config is set.",
+        type=semvertag_or_latest,
+        default=__version__)
 
     # worker
     parser.add_argument(
@@ -52,7 +54,7 @@ def add_args_join(parser: argparse.ArgumentParser):
         type=str,
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
-                  on which to install primaza or worker, default: \
+                  to join, default: \
                   current kubeconfig context",
         default=None)
 
@@ -87,7 +89,7 @@ def add_args_join(parser: argparse.ArgumentParser):
         "-l", "--tenant-kubeconfig",
         dest="main_kubeconfig",
         required=False,
-        help=f"path to kubeconfig file, default: KUBECONFIG \
+        help=f"path to kubeconfig file for the tenant, default: KUBECONFIG \
                    environment variable if set, otherwise \
                    {(os.path.join(Path.home(),'.kube','config'))}",
         type=existing_file,
@@ -98,7 +100,7 @@ def add_args_join(parser: argparse.ArgumentParser):
         dest="tenant_context",
         required=False,
         help="name of cluster, as it appears in kubeconfig, \
-                on which Primaza is installed. Default: \
+                on which primaza tenant was created. Default: \
                 current kubeconfig context",
         type=str,
         default=None)
@@ -114,7 +116,6 @@ def add_args_join(parser: argparse.ArgumentParser):
 
 
 def join_cluster(args):
-    validate(args)
 
     try:
         main = MainCluster(
@@ -142,8 +143,3 @@ def join_cluster(args):
         print(f"\nAn exception occurred executing the "
               f"worker join function: {e}", file=sys.stderr)
         raise e
-
-
-def validate(args):
-    if not args.config and not args.version:
-        raise AtLeastOneError("--config", "--version")


### PR DESCRIPTION
For the version, the makefile creates a file when building primazactl:

`scripts/src/primazactl/version.py` 

it contains one line, for example:

`__version__ = "latest"`

The value the version is set to is based on the VERSION variable in the Makefile, which can be overwritten by setting an environment variable, for example:

`export VERSION="v.0.0.1"`

This is then used in the cmd files to set a default version if one is not specified for a command.

The file   `scripts/src/primazactl/version.py`  has been added to git ignore. I could create one with version set to latest  and then set the ignore but would be concerned about a release code zip having a different value to that set during build.

The rest of the changes are script, makefile and readme updates to reflect the new cli previously created. Under new scheme terminology is awkward. "main" is easily replaced by "tenant", but "join worker" is now "join cluster" so difficult to refer to, esepcially with respect to the service and application namespaces. Have done my best lol.

Also I added a link to the primaza README - but concerned it does not use the term "tenant" or refer to "join cluster" at all, so may be very confusing to users.
